### PR TITLE
Fixed link to UNIFY project

### DIFF
--- a/escape/doc/source/index.rst
+++ b/escape/doc/source/index.rst
@@ -10,7 +10,7 @@ general prototyping framework which supports the development of several parts of
 the service chaining architecture including VNF implementation, traffic steering,
 virtual network embedding, etc.  On the other hand, ESCAPE is a proof of concept
 prototype implementing a novel SFC (Service Function Chaining) architecture proposed
-by `EU FP7 UNIFY project <https://www.fp7-unify.eu/>`__.
+by `EU FP7 UNIFY project <https://www.eict.de/projekte/#project-23>`__.
 It is a realization of the UNIFY service programming and orchestration framework
 which enables the joint programming and virtualization of cloud and networking
 resources.


### PR DESCRIPTION
The https link was broken and the http version redirects to the page that I now used instead.